### PR TITLE
fix(penpot): cannot use literal booleans, but instead the string representations

### DIFF
--- a/templates-2.0.json
+++ b/templates-2.0.json
@@ -113,12 +113,12 @@
           "select": [
             {
               "text": "Yes, enable telemetry",
-              "value": true,
+              "value": "true",
               "default": true
             },
             {
               "text": "No, disable telemetry",
-              "value": false
+              "value": "false"
             }
           ],
           "description": "When enabled, a periodical process will send anonymous data about this instance."


### PR DESCRIPTION
Resolves error:
```
cannot unmarshal bool into Go struct field
```